### PR TITLE
Add custom target cursor for project cards

### DIFF
--- a/firstmodelglm4.5portfolio.html
+++ b/firstmodelglm4.5portfolio.html
@@ -262,6 +262,65 @@
             transform: translateX(30px);
         }
 
+        /* Target Cursor styles */
+        .target-cursor-wrapper {
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 0;
+            height: 0;
+            pointer-events: none;
+            z-index: 9999;
+            mix-blend-mode: difference;
+            transform: translate(-50%, -50%);
+        }
+
+        .target-cursor-dot {
+            position: absolute;
+            left: 50%;
+            top: 50%;
+            width: 4px;
+            height: 4px;
+            background: #fff;
+            border-radius: 50%;
+            transform: translate(-50%, -50%);
+            will-change: transform;
+        }
+
+        .target-cursor-corner {
+            position: absolute;
+            left: 50%;
+            top: 50%;
+            width: 12px;
+            height: 12px;
+            border: 3px solid #fff;
+            will-change: transform;
+        }
+
+        .corner-tl {
+            transform: translate(-150%, -150%);
+            border-right: none;
+            border-bottom: none;
+        }
+
+        .corner-tr {
+            transform: translate(50%, -150%);
+            border-left: none;
+            border-bottom: none;
+        }
+
+        .corner-br {
+            transform: translate(50%, 50%);
+            border-left: none;
+            border-top: none;
+        }
+
+        .corner-bl {
+            transform: translate(-150%, 50%);
+            border-right: none;
+            border-top: none;
+        }
+
         /* Responsive */
         @media (max-width: 768px) {
             .timeline-line {
@@ -273,6 +332,7 @@
             }
         }
     </style>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/gsap.min.js" crossorigin></script>
 </head>
 <body>
     <!-- Loading Screen -->
@@ -285,6 +345,15 @@
 
     <!-- Particles Background -->
     <div id="particles-js"></div>
+
+    <!-- Custom Target Cursor -->
+    <div class="target-cursor-wrapper" id="targetCursor" aria-hidden="true">
+        <div class="target-cursor-dot"></div>
+        <div class="target-cursor-corner corner-tl"></div>
+        <div class="target-cursor-corner corner-tr"></div>
+        <div class="target-cursor-corner corner-br"></div>
+        <div class="target-cursor-corner corner-bl"></div>
+    </div>
 
     <!-- Navigation -->
     <nav class="fixed top-0 w-full bg-gray-900/80 backdrop-blur-md z-50 transition-all duration-300" id="navbar">
@@ -1104,6 +1173,72 @@
         }
 
         createParticles();
+
+        // ----- Target Cursor for project cards -----
+        const cursor = document.getElementById('targetCursor');
+        const corners = cursor.querySelectorAll('.target-cursor-corner');
+        const spinDuration = 2;
+        const borderWidth = 3;
+        const cornerSize = 12;
+
+        let spinTl = gsap.timeline({ repeat: -1 })
+            .to(cursor, { rotation: '+=360', duration: spinDuration, ease: 'none' });
+
+        function moveCursor(x, y) {
+            gsap.to(cursor, { x, y, duration: 0.1, ease: 'power3.out' });
+        }
+
+        window.addEventListener('mousemove', e => moveCursor(e.clientX, e.clientY));
+
+        function updateCorners(card, mouseX, mouseY) {
+            const rect = card.getBoundingClientRect();
+            const cursorRect = cursor.getBoundingClientRect();
+            const cx = cursorRect.left + cursorRect.width / 2;
+            const cy = cursorRect.top + cursorRect.height / 2;
+
+            const offsets = [
+                { x: rect.left - cx - borderWidth, y: rect.top - cy - borderWidth },
+                { x: rect.right - cx + borderWidth - cornerSize, y: rect.top - cy - borderWidth },
+                { x: rect.right - cx + borderWidth - cornerSize, y: rect.bottom - cy + borderWidth - cornerSize },
+                { x: rect.left - cx - borderWidth, y: rect.bottom - cy + borderWidth - cornerSize },
+            ];
+
+            corners.forEach((corner, i) => {
+                gsap.to(corner, { x: offsets[i].x, y: offsets[i].y, duration: 0.2, ease: 'power2.out' });
+            });
+        }
+
+        function resetCorners() {
+            const positions = [
+                { x: -cornerSize * 1.5, y: -cornerSize * 1.5 },
+                { x: cornerSize * 0.5, y: -cornerSize * 1.5 },
+                { x: cornerSize * 0.5, y: cornerSize * 0.5 },
+                { x: -cornerSize * 1.5, y: cornerSize * 0.5 },
+            ];
+            corners.forEach((corner, i) => {
+                gsap.to(corner, { x: positions[i].x, y: positions[i].y, duration: 0.3, ease: 'power3.out' });
+            });
+        }
+
+        document.querySelectorAll('.project-card').forEach(card => {
+            card.addEventListener('mouseenter', e => {
+                spinTl.pause();
+                gsap.set(cursor, { rotation: 0 });
+                updateCorners(card, e.clientX, e.clientY);
+            });
+
+            card.addEventListener('mousemove', e => {
+                updateCorners(card, e.clientX, e.clientY);
+            });
+
+            card.addEventListener('mouseleave', () => {
+                resetCorners();
+                spinTl.play();
+            });
+        });
+
+        document.body.style.cursor = 'none';
+        resetCorners();
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- style custom target cursor elements
- add markup for cursor wrapper
- include GSAP for animations
- implement JS to animate cursor around `.project-card` items

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688a5b05f4a88320b19d5d4ad84c5e0e