### PR TITLE
Add functional theme switch

### DIFF
--- a/firstmodelglm4.5portfolio.html
+++ b/firstmodelglm4.5portfolio.html
@@ -15,6 +15,10 @@
             --dark: #0f172a;
             --light: #f8fafc;
         }
+        .light-theme {
+            --dark: #f8fafc;
+            --light: #0f172a;
+        }
 
         * {
             margin: 0;
@@ -235,31 +239,174 @@
             z-index: -1;
         }
 
-        /* Dark Mode Toggle */
-        .dark-mode-toggle {
+        /* Theme Switch */
+        .switch {
             position: relative;
             width: 60px;
             height: 30px;
-            background: rgba(255, 255, 255, 0.1);
-            border-radius: 15px;
-            cursor: pointer;
-            transition: all 0.3s ease;
+            box-sizing: border-box;
+            padding: 3px;
+            background: #0d0d0d;
+            border-radius: 6px;
+            box-shadow: inset 0 1px 1px 1px rgba(0, 0, 0, 0.5), 0 1px 0 0 rgba(255, 255, 255, 0.1);
         }
-
-        .dark-mode-toggle::before {
-            content: '';
+        .switch input[type="checkbox"] {
             position: absolute;
-            top: 3px;
-            left: 3px;
-            width: 24px;
-            height: 24px;
-            background: var(--primary);
-            border-radius: 50%;
-            transition: all 0.3s ease;
+            z-index: 1;
+            width: 100%;
+            height: 100%;
+            opacity: 0;
+            cursor: pointer;
         }
-
-        .dark-mode-toggle.active::before {
-            transform: translateX(30px);
+        .switch input[type="checkbox"] + label {
+            position: relative;
+            display: block;
+            left: 0;
+            width: 50%;
+            height: 100%;
+            background: #1b1c1c;
+            border-radius: 3px;
+            box-shadow: inset 0 1px 0 0 rgba(255, 255, 255, 0.1);
+            transition: all 0.5s ease-in-out;
+        }
+        .switch input[type="checkbox"] + label:before {
+            content: "";
+            display: inline-block;
+            width: 5px;
+            height: 5px;
+            margin-left: 10px;
+            background: #fff;
+            border-radius: 50%;
+            vertical-align: middle;
+            box-shadow: 0 0 5px 2px rgba(165, 15, 15, 0.9), 0 0 3px 1px rgba(165, 15, 15, 0.9);
+            transition: all 0.5s ease-in-out;
+        }
+        .switch input[type="checkbox"] + label:after {
+            content: "";
+            display: inline-block;
+            width: 0;
+            height: 100%;
+            vertical-align: middle;
+        }
+        .switch input[type="checkbox"] + label i {
+            display: block;
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            width: 3px;
+            height: 24px;
+            margin-top: -12px;
+            margin-left: -1.5px;
+            border-radius: 2px;
+            background: #0d0d0d;
+            box-shadow: 0 1px 0 0 rgba(255, 255, 255, 0.3);
+        }
+        .switch input[type="checkbox"] + label i:before,
+        .switch input[type="checkbox"] + label i:after {
+            content: "";
+            display: block;
+            position: absolute;
+            width: 100%;
+            height: 100%;
+            border-radius: 2px;
+            background: #0d0d0d;
+            box-shadow: 0 1px 0 0 rgba(255, 255, 255, 0.3);
+        }
+        .switch input[type="checkbox"] + label i:before {
+            left: -7px;
+        }
+        .switch input[type="checkbox"] + label i:after {
+            left: 7px;
+        }
+        .switch input[type="checkbox"]:checked + label {
+            left: 50%;
+        }
+        .switch input[type="checkbox"]:checked + label:before {
+            box-shadow: 0 0 5px 2px rgba(15, 165, 70, 0.9), 0 0 3px 1px rgba(15, 165, 70, 0.9);
+        }
+        .switch {
+            position: relative;
+            width: 60px;
+            height: 30px;
+            box-sizing: border-box;
+            padding: 3px;
+            background: #0d0d0d;
+            border-radius: 6px;
+            box-shadow: inset 0 1px 1px 1px rgba(0, 0, 0, 0.5), 0 1px 0 0 rgba(255, 255, 255, 0.1);
+        }
+        .switch input[type="checkbox"] {
+            position: absolute;
+            z-index: 1;
+            width: 100%;
+            height: 100%;
+            opacity: 0;
+            cursor: pointer;
+        }
+        .switch input[type="checkbox"] + label {
+            position: relative;
+            display: block;
+            left: 0;
+            width: 50%;
+            height: 100%;
+            background: #1b1c1c;
+            border-radius: 3px;
+            box-shadow: inset 0 1px 0 0 rgba(255, 255, 255, 0.1);
+            transition: all 0.5s ease-in-out;
+        }
+        .switch input[type="checkbox"] + label:before {
+            content: "";
+            display: inline-block;
+            width: 5px;
+            height: 5px;
+            margin-left: 10px;
+            background: #fff;
+            border-radius: 50%;
+            vertical-align: middle;
+            box-shadow: 0 0 5px 2px rgba(165, 15, 15, 0.9), 0 0 3px 1px rgba(165, 15, 15, 0.9);
+            transition: all 0.5s ease-in-out;
+        }
+        .switch input[type="checkbox"] + label:after {
+            content: "";
+            display: inline-block;
+            width: 0;
+            height: 100%;
+            vertical-align: middle;
+        }
+        .switch input[type="checkbox"] + label i {
+            display: block;
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            width: 3px;
+            height: 24px;
+            margin-top: -12px;
+            margin-left: -1.5px;
+            border-radius: 2px;
+            background: #0d0d0d;
+            box-shadow: 0 1px 0 0 rgba(255, 255, 255, 0.3);
+        }
+        .switch input[type="checkbox"] + label i:before,
+        .switch input[type="checkbox"] + label i:after {
+            content: "";
+            display: block;
+            position: absolute;
+            width: 100%;
+            height: 100%;
+            border-radius: 2px;
+            background: #0d0d0d;
+            box-shadow: 0 1px 0 0 rgba(255, 255, 255, 0.3);
+        }
+        .switch input[type="checkbox"] + label i:before {
+            left: -7px;
+        }
+        .switch input[type="checkbox"] + label i:after {
+            left: 7px;
+        }
+        .switch input[type="checkbox"]:checked + label {
+            left: 50%;
+        }
+        .switch input[type="checkbox"]:checked + label:before {
+            box-shadow: 0 0 5px 2px rgba(15, 165, 70, 0.9), 0 0 3px 1px rgba(15, 165, 70, 0.9);
         }
 
         /* Target Cursor styles */
@@ -374,7 +521,12 @@
                 </div>
 
                 <div class="flex items-center space-x-4">
-                    <div class="dark-mode-toggle" id="darkModeToggle"></div>
+                    <div class="switch">
+                        <input id="themeToggle" type="checkbox" />
+                        <label class="toggle" for="themeToggle">
+                            <i></i>
+                        </label>
+                    </div>
                     <button class="md:hidden text-white" id="mobileMenuBtn">
                         <i class="fas fa-bars text-2xl"></i>
                     </button>
@@ -1123,11 +1275,22 @@
             });
         });
 
-        // Dark Mode Toggle (placeholder functionality)
-        const darkModeToggle = document.getElementById('darkModeToggle');
-        darkModeToggle.addEventListener('click', () => {
-            darkModeToggle.classList.toggle('active');
-            // In a real implementation, this would toggle dark/light mode
+        // Theme Toggle functionality
+        const themeToggle = document.getElementById("themeToggle");
+        const body = document.body;
+        const savedTheme = localStorage.getItem("theme");
+        if (savedTheme === "light") {
+            body.classList.add("light-theme");
+            themeToggle.checked = true;
+        }
+        themeToggle.addEventListener("change", () => {
+            if (themeToggle.checked) {
+                body.classList.add("light-theme");
+                localStorage.setItem("theme", "light");
+            } else {
+                body.classList.remove("light-theme");
+                localStorage.setItem("theme", "dark");
+            }
         });
 
         // Intersection Observer for animations


### PR DESCRIPTION
## Summary
- implement a light theme by adding CSS variables
- replace old dark mode toggle with new switch markup and styles
- make the switch toggle between dark and light theme using localStorage

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688a5f2afab883209c8bfd05d57bb88d