### PR TITLE
Add Three.js animated hero background

### DIFF
--- a/firstmodelglm4.5portfolio.html
+++ b/firstmodelglm4.5portfolio.html
@@ -334,6 +334,7 @@
         }
     </style>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/gsap.min.js" crossorigin></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r152/three.min.js" crossorigin></script>
 </head>
 <body>
     <!-- Loading Screen -->
@@ -401,6 +402,7 @@
 
     <!-- Hero Section -->
     <section id="home" class="hero-bg min-h-screen flex items-center justify-center relative">
+        <canvas id="heroCanvas" class="absolute inset-0 w-full h-full pointer-events-none"></canvas>
         <div class="container mx-auto px-6 text-center relative z-10">
             <div class="text-animation">
                 <h1 class="text-5xl md:text-7xl font-bold mb-6 text-white">
@@ -1040,6 +1042,39 @@
             const lang = e.target.value;
             localStorage.setItem('language', lang);
             loadLanguage(lang);
+        });
+
+        // Three.js Hero Background
+        const heroCanvas = document.getElementById('heroCanvas');
+        const scene = new THREE.Scene();
+        const camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 1000);
+        const renderer = new THREE.WebGLRenderer({ canvas: heroCanvas, alpha: true });
+        renderer.setPixelRatio(window.devicePixelRatio);
+        renderer.setSize(window.innerWidth, window.innerHeight);
+        camera.position.z = 5;
+
+        const starGeometry = new THREE.BufferGeometry();
+        const starCount = 500;
+        const starPositions = new Float32Array(starCount * 3);
+        for (let i = 0; i < starCount * 3; i++) {
+            starPositions[i] = (Math.random() - 0.5) * 20;
+        }
+        starGeometry.setAttribute('position', new THREE.BufferAttribute(starPositions, 3));
+        const starMaterial = new THREE.PointsMaterial({ color: 0xffffff, size: 0.05 });
+        const stars = new THREE.Points(starGeometry, starMaterial);
+        scene.add(stars);
+
+        function animate() {
+            requestAnimationFrame(animate);
+            stars.rotation.y += 0.0005;
+            renderer.render(scene, camera);
+        }
+        animate();
+
+        window.addEventListener('resize', () => {
+            camera.aspect = window.innerWidth / window.innerHeight;
+            camera.updateProjectionMatrix();
+            renderer.setSize(window.innerWidth, window.innerHeight);
         });
 
         // Loader


### PR DESCRIPTION
## Summary
- include Three.js via CDN and add heroCanvas canvas in hero section
- implement animated star field using Three.js targeting heroCanvas
- handle window resizing for Three.js renderer

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68912088043883209c1a233e1321f653